### PR TITLE
prevent syntax error from occurring

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,3 +1,4 @@
+'use strict'
 /**
  * Sample Script
  */


### PR DESCRIPTION
Block-scoped declarations (let, const, function, class) not yet supported outside strict mode