### PR TITLE
Fix regexp for getId

### DIFF
--- a/src/aws.js
+++ b/src/aws.js
@@ -20,7 +20,10 @@ exports.getId = function() {
 
   let authorized = data => data.User.Arn
   let unauthorized = error => error.message
-  let match = arn => arn.match(/arn:aws:sts::(\d+):/)[1]
+  let match = arn => {
+    return arn.match(/arn:aws:iam::(\d+):/) ?
+      arn.match(/arn:aws:iam::(\d+):/)[1] : arn.match(/arn:aws:sts::(\d+):/)[1]
+  }
 
   return iam.getUser({}).promise().then(authorized).catch(unauthorized).then(match)
 }


### PR DESCRIPTION
# context
Hi @johnagan, thank you for this great boilerplate! I'm happy if you look over this PR.

I got the following error at https://github.com/johnagan/serverless-slackbot/blob/master/src/aws.js#L23 . In this situation, the value in the `arn` variable is `arn:aws:iam::108111000000:user/serverless_bot` . So I added some code to handle it.

```
TypeError: Cannot read property '1' of null
at match (/var/task/src/aws.js:27:54)
at iam.getUser.promise.then.catch.then.a (/var/task/src/aws.js:31:12)
at <anonymous>
at process._tickDomainCallback (internal/process/next_tick.js:228:7)
```